### PR TITLE
Update data.ts

### DIFF
--- a/docs/nav/data.ts
+++ b/docs/nav/data.ts
@@ -206,13 +206,6 @@ export const NAV_DATA: NavData[] = [
         link: 'https://www.mcappx.com/',
       },
       {
-        //icon: 'https://www.fastmirror.net/favicon.ico',
-        icon: '/icons/nav/资源站/无极镜像.ico',
-        title: 'FastMirror 无极镜像',
-        desc: '快速下载多种MC服务端核心',
-        link: 'https://www.fastmirror.net/#/home',
-      },
-      {
         //icon: 'https://www.curseforge.com/favicon.ico',
         icon: '/icons/nav/资源站/CurseForge.ico',
         title: 'CurseForge',


### PR DESCRIPTION
删除无极镜像
原因：查看多个服务端更新时间都在24年，或许是摆烂力