### PR TITLE
Fix MSCPO link in navigation configuration

### DIFF
--- a/docs/.vitepress/configs/i18n/en_US/nav.ts
+++ b/docs/.vitepress/configs/i18n/en_US/nav.ts
@@ -13,9 +13,10 @@ export const nav: DefaultTheme.Config['nav'] = [
   {
     text: "Friendly Links",
               items: [
+                { text: "LynSeq", link: "https://lynseq.com" },
                 { text: "MCFlare", link: "https://forum.mcflare.com" },
                 { text: "HuggingAI", link: "https://huggingai.org" },
-                { text: "MSCPO", link: "https://mscpo.top/" },
+                { text: "MSCPO", link: "https://mscpo.com/" },
                 { text: "随风的个人网站", link: "https://zhuyuxuan.link/" },
                 { text: "风梨网", link: "https://www.flweb.cn/" },
               ]

--- a/docs/.vitepress/configs/i18n/zh-classical/nav.ts
+++ b/docs/.vitepress/configs/i18n/zh-classical/nav.ts
@@ -13,9 +13,10 @@ export const nav: DefaultTheme.Config['nav'] = [
   {
     text: "友情鏈接",
               items: [
+                { text: "鈴序科技", link: "https://lynseq.com" },
                 { text: "MCFlare", link: "https://forum.mcflare.com" },
                 { text: "HuggingAI", link: "https://huggingai.org" },
-                { text: "MSCPO", link: "https://mscpo.top/" },
+                { text: "MSCPO", link: "https://mscpo.com/" },
                 { text: "隨風的個人網站", link: "https://zhuyuxuan.link/" },
                 { text: "鳳梨社區", link: "https://www.flweb.cn/" },
               ]

--- a/docs/.vitepress/configs/nav.ts
+++ b/docs/.vitepress/configs/nav.ts
@@ -13,9 +13,10 @@ export const nav: DefaultTheme.Config['nav'] = [
   {
     text: "友情链接",
               items: [
+                { text: "铃序科技", link: "https://lynseq.com" },
                 { text: "MCFlare", link: "https://forum.mcflare.com" },
                 { text: "HuggingAI", link: "https://huggingai.org" },
-                { text: "MSCPO", link: "https://mscpo.top/" },
+                { text: "MSCPO", link: "https://mscpo.com/" },
                 { text: "随风的个人网站", link: "https://zhuyuxuan.link/" },
                 { text: "风梨网", link: "https://www.flweb.cn/" },
               ]


### PR DESCRIPTION
Updated the link for MSCPO from 'https://mscpo.top/' to 'https://mscpo.com/'. 添加铃序科技链接

铃序科技的英文应该是“LynSeq”，文言文就保持简中不变